### PR TITLE
fix: convert Spanish and Turkish files to script tag format

### DIFF
--- a/translations/es.js
+++ b/translations/es.js
@@ -1,4 +1,5 @@
-export const es = {
+window.translations = window.translations || {};
+window.translations.es = {
   language: 'Idioma',
   title: 'Tutorial de Creación de Escuadrones',
   subtitle: 'Formaciones de Ataque y Defensa',

--- a/translations/tr.js
+++ b/translations/tr.js
@@ -1,4 +1,5 @@
-export const tr = {
+window.translations = window.translations || {};
+window.translations.tr = {
   language: 'Dil',
   title: 'Takım Oluşturma Eğitimi',
   subtitle: 'Saldırı ve Savunma Dizilimleri',


### PR DESCRIPTION
- Changed 'export const es' to 'window.translations.es' in es.js
- Changed 'export const tr' to 'window.translations.tr' in tr.js
- Fixed syntax errors when loading from file system
- Spanish and Turkish languages now work properly without server